### PR TITLE
Add MLIR to 20201001

### DIFF
--- a/2020-10-01.md
+++ b/2020-10-01.md
@@ -83,6 +83,29 @@ Bilibili：https://www.bilibili.com/read/readlist/rl199373
 
 ## MLIR
 
+PLCT实验室张洪滨向MLIR repo提交patch：
+
+Committed:
+
+**[mlir] expose affine map to C API**
+
+https://github.com/llvm/llvm-project/commit/b76f523be6ea606d9cf494e247546cec1cd7f209
+
+```
+This patch provides C API for MLIR affine map.
+- Implement C API for AffineMap class.
+- Add Utils.h to include/mlir/CAPI/, and move the definition of the CallbackOstream to Utils.h to make sure mlirAffineMapPrint work correct.
+- Add TODO for exposing the C API related to AffineExpr and mutable affine map.
+
+Differential Revision: https://reviews.llvm.org/D87617
+```
+
+Reviewing:
+
+**[mlir] Add Float Attribute, Integer Attribute and Bool Attribute subclasses to python bindings.**
+
+Differential Revision: https://reviews.llvm.org/D88531
+
 ## CIRCT
 
 ## OpenROAD


### PR DESCRIPTION
添加MLIR已进入主分支patch：[mlir] expose affine map to C API，正在review的patch：[mlir] Add Float Attribute, Integer Attribute and Bool Attribute subclasses to python bindings.
