### PR TITLE
Add MLIR to 20201016

### DIFF
--- a/2020-10-16.md
+++ b/2020-10-16.md
@@ -54,7 +54,28 @@ TODO 史宁宁
 
 ## MLIR
 
-TODO 张洪滨
+PLCT实验室张洪滨向 MLIR repo 提交 patch：
+
+Committed:
+
+**[mlir] Add Float Attribute, Integer Attribute and Bool Attribute subclasses to python bindings.**
+
+https://github.com/llvm/llvm-project/commit/2fc0d4a8e83807d57f8d586af82934f94dead5e3
+
+```
+Based on PyAttribute and PyConcreteAttribute classes, this patch implements the bindings of Float Attribute, Integer Attribute and Bool Attribute subclasses.
+This patch also defines the `mlirFloatAttrDoubleGetChecked` C API which is bound with the `FloatAttr.get_typed` python method.
+
+Differential Revision: https://reviews.llvm.org/D88531
+```
+
+除此之外，MLIR Python Bindings项目经过桥接，最近已经被`mlir-npcomp`项目初步使用，正在分析相关[PR](https://github.com/llvm/mlir-npcomp/pull/77). 下一步的Python Bindings工作需要等待[D89363](https://reviews.llvm.org/D89363)提交之后，再进行下一步绑定。
+
+**MLIR知乎文章**
+
+MLIR 诊断系统 - Source Locations - https://zhuanlan.zhihu.com/p/261156885
+
+MLIR 诊断系统 - Diagnostic & Diagnostic Engine - https://zhuanlan.zhihu.com/p/262988212
 
 ## CIRCT
 


### PR DESCRIPTION
添加MLIR开源工作：

- 一个Patch提交
- 两篇知乎文章

好消息：MLIR Python Bindings已经被`mlir-npcomp`项目初步使用