### PR TITLE
Add MLIR to 20201101

### DIFF
--- a/2020-11-01.md
+++ b/2020-11-01.md
@@ -1,5 +1,5 @@
 # PLCT开源进展·第12期·2020年11月01日
- 
+
 ## 卷首语
 
 TODO 吴伟
@@ -85,7 +85,25 @@ spike网卡支持功能代码已初步完成，正在进行代码整理以及进
 
 ## MLIR
 
-TODO 张洪滨
+PLCT实验室张洪滨向 MLIR repo 提交 patch：
+
+Committed:
+
+**[mlir] Expose affine expression to C API**
+
+https://github.com/llvm/llvm-project/commit/448f25c86b79aebae90718938b6a2cb4c782e57d
+
+```
+This patch provides C API for MLIR affine expression.
+- Implement C API for methods of AffineExpr class.
+- Implement C API for methods of derived classes (AffineBinaryOpExpr, AffineDimExpr, AffineSymbolExpr, and AffineConstantExpr).
+
+Differential Revision: https://reviews.llvm.org/D89856
+```
+
+**MLIR知乎文章**
+
+MLIR C API开发流程 -- 以Affine Expr为例 - https://zhuanlan.zhihu.com/p/267200107
 
 ## CIRCT
 
@@ -121,7 +139,9 @@ TODO 张尹
 
 ## 其他工作
 
-TODO all
+知乎文章
+
+命令行下载 + Batch Mode安装 Vivado - https://zhuanlan.zhihu.com/p/265963177
 
 ## 参考链接
 


### PR DESCRIPTION
添加开源工作到20201101：

- 一个MLIR Patch：[mlir] Expose affine expression to C API 
- 两篇知乎文章：MLIR C API开发流程 -- 以Affine Expr为例 & 命令行下载 + Batch Mode安装 Vivado

除此之外，MLIR + RISC-V + FPGA还在继续探索。